### PR TITLE
julia - implement normalized iteration count

### DIFF
--- a/julia_sets/main.js
+++ b/julia_sets/main.js
@@ -59,7 +59,7 @@ for (let a = from; a <= to; a += step) {
 
         ctx.fillRect(x, y, 5, 5);
         if (colorMap[iter] == null) {
-            colorMap[iter] = generateColor();
+            colorMap[iter] = generateColor(iter);
         }
         ctx.fillStyle = colorMap[iter];
     }

--- a/julia_sets/main.js
+++ b/julia_sets/main.js
@@ -1,5 +1,6 @@
+// Normalized Iteration Count algorithm inspired from https://solarianprogrammer.com/2013/02/28/mandelbrot-set-cpp-11/
 const generateColor = (iter) => {
-    var t = iter/maxIteration; // Normalized Iteration Count
+    var t = iter/maxIteration;
     var r = 2.5*t**rlp*(1-t)**rrp;
     var g = 2.5*t**glp*(1-t)**grp;
     var b = 2.5*t**blp*(1-t)**brp; 

--- a/julia_sets/main.js
+++ b/julia_sets/main.js
@@ -1,8 +1,18 @@
-// Reference: https://en.wikipedia.org/wiki/Julia_set
-const generateColor = () => {
-    const randomColor = Math.floor(Math.random() * 16777215).toString(16);
-    return `#${randomColor}`
+const generateColor = (iter) => {
+    var t = iter/maxIteration; // Normalized Iteration Count
+    var r = 2.5*t**rlp*(1-t)**rrp;
+    var g = 2.5*t**glp*(1-t)**grp;
+    var b = 2.5*t**blp*(1-t)**brp; 
+    // factor of 2 caps off parametric functions at 1, 
+    // but 2.5 potential overflow is not a big deal as rgb values higher than 255 are capped
+    r = Math.floor(r*255); g = Math.floor(g*255); b = Math.floor(b*255);
+    return `rgb(${r},${g},${b})`
 };
+
+// cmap parametric functions zeros multiplicities, randomized between 0.5 and 2
+const rlp = Math.random()*1.5+0.5; const rrp = Math.random()*1.5+0.5;
+const glp = Math.random()*1.5+0.5; const grp = Math.random()*1.5+0.5;
+const blp = Math.random()*1.5+0.5; const brp = Math.random()*1.5+0.5;
 
 const WIDTH = 1000;
 


### PR DESCRIPTION
I've been researching colouring methods of Mandelbrot and Julia sets for a while and it seems that the Normalized Iteration Count algorithm described [here](https://solarianprogrammer.com/2013/02/28/mandelbrot-set-cpp-11/) might be worth mentioning. 

I saw that the code you had written would randomize colourings and didn't want to take that feature away, so the code I wrote just randomizes the Bernstein-like polynomials' zeros' multiplicities, which in turn creates a completely new colourmap. 
I already use a very similar technique in my own fractal projects and thought it could maybe be useful here too.

edit: forgot to finish my first sentence (oops)